### PR TITLE
Fix: use style=file instead of default style.

### DIFF
--- a/clang-format-all
+++ b/clang-format-all
@@ -79,6 +79,6 @@ for dir in "$@"; do
          -o -name '*.h' \
          -o -name '*.hh' \
          -o -name '*.hpp' \) \
-         -exec "${FMT}" -i '{}' \;
+         -exec "${FMT}" -style=file -i '{}' \;
     popd &>/dev/null
 done


### PR DESCRIPTION
This script was formatting using the default clang-format file.